### PR TITLE
Bugfix: registration redirect

### DIFF
--- a/pokedex/web/controllers/user_controller.ex
+++ b/pokedex/web/controllers/user_controller.ex
@@ -9,10 +9,10 @@ defmodule Pokedex.UserController do
     render conn, "new.html", changeset: changeset
   end
 
-  # def index(conn, _params) do
-  #   users = Repo.all(Pokedex.User)
-  #   render conn, "index.html", users: users
-  # end
+  def index(conn, _params) do
+    users = Repo.all(Pokedex.User)
+    render conn, "index.html", users: users
+  end
 
   def show(conn, %{"id" => id}) do
     user = Repo.get(Pokedex.User, id)


### PR DESCRIPTION
After registration, the new user is redirected to `/users` (see happy path in `UserController.create`). The definition of this action was commented out. It either needs to be un-commented, as I have done here, or `UserController.create` needs to redirect somewhere else.